### PR TITLE
Remove features.h

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -3,7 +3,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <SDL.h>
-#include "features.h"
+#include "types.h"
 #include "util.h"
 
 enum {

--- a/src/features.h
+++ b/src/features.h
@@ -1,9 +1,0 @@
-// This file declares extensions to the base game
-#ifndef ZELDA3_FEATURES_H_
-#define ZELDA3_FEATURES_H_
-
-#include "types.h"
-
-// Special RAM locations that are unused but I use for compat things.
-
-#endif  // ZELDA3_FEATURES_H_

--- a/src/sm.vcxproj
+++ b/src/sm.vcxproj
@@ -234,7 +234,6 @@
     <ClInclude Include="config.h" />
     <ClInclude Include="enemy_defs.h" />
     <ClInclude Include="enemy_types.h" />
-    <ClInclude Include="features.h" />
     <ClInclude Include="funcs.h" />
     <ClInclude Include="glsl_shader.h" />
     <ClInclude Include="ida_types.h" />

--- a/src/sm.vcxproj.filters
+++ b/src/sm.vcxproj.filters
@@ -209,9 +209,6 @@
     <ClInclude Include="config.h">
       <Filter>Source Files</Filter>
     </ClInclude>
-    <ClInclude Include="features.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="util.h">
       <Filter>Header Files</Filter>
     </ClInclude>


### PR DESCRIPTION

>When using some combination of preprocessor flags (-M) and some feature_test_macros() on Linux, "features.h" is erroneously being detected as the stdlib's <features.h>, causing unfathomable errors and other Bad Things to happen with build systems. This is arguably some sort of compiler bug, but <> vs "" is implementation defined so this is theoretically possible to hit on other compilers that use glibc's headers.
>
>This header only includes "types.h", and is itself only #include'd in one file, config.c. So just delete the file and include "types.h" directly inside config.c. Other references to features.h were deleted in the VS project files.


### Description
See commit message above

### Will this Pull Request break anything? 
It shouldn't

### Suggested Testing Steps
Build it and see if it breaks. I have tested this on Linux. 
