### PR TITLE
Enum/ODR fix

### DIFF
--- a/src/ida_types.h
+++ b/src/ida_types.h
@@ -297,6 +297,7 @@ enum ElevatorDirection {  // 0x7E0799
 };
 
 enum RoomIndex {  // 0x7E079D
+  kNUM_ROOM_IDX = 0x0 // none for now
 };
 
 enum AreaIndex {  // 0x7E079F

--- a/src/sm_90.h
+++ b/src/sm_90.h
@@ -61,7 +61,8 @@ uint8 kSamusFramesForUnderwaterSfx[] = {
   0, 201,   4,   0,
 };
 
-const uint8 *kPauseMenuMapData[8];
+// declared in sm_82.h, extern here to not break ODR with other variables in sm_82.c
+extern const uint8 *kPauseMenuMapData[8];
 
 LongPtr kPauseMenuMapTilemaps_90[] = {
   0x9000, 0xb5, 0x8000, 0xb5, 0xa000, 0xb5, 0xb000, 0xb5, 0xc000, 0xb5, 0xd000, 0xb5, 0xe000, 0xb5,


### PR DESCRIPTION
### Description
<!-- What is the purpose of this PR and what it adds? -->
There were two issues from 45fcc94c37710d00deabe3d7cc24076caf1a9ca3 when building with GCC on linux

1. An empty enum (which gcc errors on)
2. Breaking the ODR with double declaring `kPauseMenuMapData` in two files

### Will this Pull Request break anything? 
<!-- Will it break the compiling? -->
It shouldn't, but I'd appreciate some testing

### Suggested Testing Steps
See if anything breaks


Note that I'm testing with an empty file now as I lost my saves. If anyone has a save I can borrow I'd appreciate it