### PR TITLE
Fixes crash in main screen when using MSU1 files/running only RM_MINE mode

### DIFF
--- a/src/sm_82.c
+++ b/src/sm_82.c
@@ -608,6 +608,9 @@ static Func_V_Coroutine *const kGameStateFuncs[45] = {
 };
 
 CoroutineRet RunOneFrameOfGameInner(void) {
+  if (game_state == 0xffff) {
+    coroutine_state_0 = 3;
+  }
   int st = coroutine_state_0;
   // This uses manual coroutine handling because of the 
   // kGameStateFuncs[game_state]() thing, we need to make


### PR DESCRIPTION
Fixes crash when returning from file menu back to main screen when using MSU1 files/when in RM_MINE game mode.
